### PR TITLE
feat: expose „show at login“ setting to determine if scan screen should be shown

### DIFF
--- a/installer/installer/Info.plist
+++ b/installer/installer/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.5.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.4.1</string>
+	<string>1.5.0</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/loginItem/loginItem/Info.plist
+++ b/loginItem/loginItem/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.5.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.4.1</string>
+	<string>1.5.0</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/mainApp/mainApp.xcodeproj/project.pbxproj
+++ b/mainApp/mainApp.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/mainApp/mainApp/AppDelegate.m
+++ b/mainApp/mainApp/AppDelegate.m
@@ -69,8 +69,13 @@
     // default to showing scan window
     else
     {
-        //show scan window
-        [self showScan:nil];
+        NSUserDefaults *sharedDefaults = [[NSUserDefaults alloc] initWithSuiteName:SUITE_NAME];
+
+        //only show scan window if allowed via preferences (default: true aka show scan)
+        if(YES == [sharedDefaults boolForKey:PREF_SHOW_AT_LOGIN]) {
+            //show scan window
+            [self showScan:nil];
+        }
         
         //if needed
         // start login item

--- a/mainApp/mainApp/Info.plist
+++ b/mainApp/mainApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.1</string>
+	<string>1.5.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.4.1</string>
+	<string>1.5.0</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/mainApp/mainApp/Preferences.xib
+++ b/mainApp/mainApp/Preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,6 +12,7 @@
                 <outlet property="ignoreAppleBinaries" destination="VjJ-hH-JvM" id="9tU-xU-Mrk"/>
                 <outlet property="noUpdates" destination="Ird-Mm-mPK" id="N1n-Bs-9TD"/>
                 <outlet property="runWithIcon" destination="eX5-VW-diC" id="WVn-Vh-haD"/>
+                <outlet property="showAtLogin" destination="U2i-I3-8NI" id="pLk-Wf-aTX"/>
                 <outlet property="startAtLogin" destination="lTh-XC-30k" id="F50-s1-FR8"/>
                 <outlet property="toolbar" destination="V8g-Ya-LK4" id="SH2-6E-QST"/>
                 <outlet property="updateButton" destination="hRJ-h6-LjN" id="IN6-yU-CZP"/>
@@ -26,7 +27,7 @@
         <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <rect key="contentRect" x="196" y="240" width="600" height="365"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="2537"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="600" height="365"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -78,7 +79,7 @@
                     </connections>
                 </button>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eX5-VW-diC">
-                    <rect key="frame" x="30" y="178" width="29" height="18"/>
+                    <rect key="frame" x="30" y="190" width="29" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="TKO-zc-4Wg">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -98,7 +99,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="445" translatesAutoresizingMaskIntoConstraints="NO" id="v4h-tE-lF5">
-                    <rect key="frame" x="64" y="151" width="353" height="28"/>
+                    <rect key="frame" x="64" y="163" width="353" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Displays an icon the status bar menu." id="E5e-Fk-59l">
                         <font key="font" size="12" name="Menlo-Regular"/>
@@ -107,7 +108,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DMQ-Ij-DMM">
-                    <rect key="frame" x="64" y="174" width="399" height="28"/>
+                    <rect key="frame" x="64" y="186" width="399" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Run With Icon" id="6py-DZ-v9k">
                         <font key="font" size="17" name="Menlo-Bold"/>
@@ -125,7 +126,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VjJ-hH-JvM">
-                    <rect key="frame" x="30" y="107" width="29" height="18"/>
+                    <rect key="frame" x="30" y="134" width="29" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="oga-c9-MlU">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -136,7 +137,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="445" translatesAutoresizingMaskIntoConstraints="NO" id="Fx3-s4-wyZ">
-                    <rect key="frame" x="64" y="71" width="458" height="36"/>
+                    <rect key="frame" x="64" y="98" width="458" height="36"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Prevents system binaries from generating alerts and appearing in scan results." id="CB4-41-E6q">
                         <font key="font" size="12" name="Menlo-Regular"/>
@@ -145,9 +146,38 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dxk-hg-c1j">
-                    <rect key="frame" x="64" y="103" width="399" height="28"/>
+                    <rect key="frame" x="64" y="130" width="399" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Ignore Apple Programs" id="njO-SW-rUE">
+                        <font key="font" size="17" name="Menlo-Bold"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="U2i-I3-8NI">
+                    <rect key="frame" x="30" y="59" width="29" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="iMJ-J5-oTi">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system" size="14"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="toggle:" target="-2" id="mCW-LN-zij"/>
+                    </connections>
+                </button>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="445" translatesAutoresizingMaskIntoConstraints="NO" id="y5F-Gg-ZY9">
+                    <rect key="frame" x="64" y="23" width="458" height="36"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Shows the current keyboard event taps on login." id="ZAG-NG-YOg">
+                        <font key="font" size="12" name="Menlo-Regular"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lc9-bV-xeX">
+                    <rect key="frame" x="64" y="55" width="399" height="28"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Show Current Status on Login" id="Fk2-Am-Djs">
                         <font key="font" size="17" name="Menlo-Bold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/mainApp/mainApp/PrefsWindowController.h
+++ b/mainApp/mainApp/PrefsWindowController.h
@@ -31,6 +31,9 @@
 //'start at login' button
 @property (weak) IBOutlet NSButton *startAtLogin;
 
+//'show at login' button
+@property (weak) IBOutlet NSButton *showAtLogin;
+
 //'run with icon' button
 @property (weak) IBOutlet NSButton *runWithIcon;
 

--- a/mainApp/mainApp/PrefsWindowController.m
+++ b/mainApp/mainApp/PrefsWindowController.m
@@ -50,7 +50,10 @@
     
     //set 'start at login' button state
     self.startAtLogin.state = [sharedDefaults boolForKey:PREF_START_AT_LOGIN];
-    
+
+    //set 'start at login' button state
+    self.sho.state = [sharedDefaults boolForKey:PREF_START_AT_LOGIN];
+
     //set 'run with icon' button state
     self.runWithIcon.state = [sharedDefaults boolForKey:PREF_RUN_WITH_ICON];
     
@@ -161,6 +164,18 @@
         
         //set 'start at login'
         [sharedDefaults setBool:(BOOL)self.startAtLogin.state forKey:PREF_START_AT_LOGIN];
+    }
+
+    //'show at login'
+    // ...just set preference
+    else if(sender == self.showAtLogin)
+    {
+        //set 'show at login'
+        [sharedDefaults setBool:(BOOL)self.showAtLogin.state forKey:PREF_SHOW_AT_LOGIN];
+      
+        //broadcast notification
+        // tells login item to hide/show icon
+        [[NSDistributedNotificationCenter defaultCenter] postNotificationName:NOTIFICATION_PREFS_CHANGED object:nil userInfo:nil deliverImmediately:YES];
     }
     
     //'run with icon'

--- a/mainApp/mainApp/Scan.xib
+++ b/mainApp/mainApp/Scan.xib
@@ -23,7 +23,7 @@
         <window title="Keyboard Event Taps" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" resizable="YES"/>
             <rect key="contentRect" x="913" y="419" width="1100" height="600"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <value key="minSize" type="size" width="1000" height="600"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="1100" height="600"/>

--- a/mainApp/mainApp/Welcome.xib
+++ b/mainApp/mainApp/Welcome.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,6 +12,7 @@
                 <outlet property="friendsView" destination="2qR-UH-6qk" id="0Pe-jK-kYJ"/>
                 <outlet property="ignoreAppleBinaries" destination="8cr-LX-DxU" id="wPJ-ST-TXc"/>
                 <outlet property="runWithIcon" destination="LHE-lc-cEL" id="NCj-Dp-UOC"/>
+                <outlet property="showStatusOnLogin" destination="9Yb-YH-360" id="Ymc-Ta-r3b"/>
                 <outlet property="startAtLogin" destination="b0q-yl-6sv" id="mql-DX-JAr"/>
                 <outlet property="welcomeView" destination="97j-sp-rBE" id="1Cx-EF-YqK"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
@@ -23,7 +24,7 @@
             <windowStyleMask key="styleMask" titled="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="700" height="350"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="2537"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
             <value key="minSize" type="size" width="700" height="350"/>
             <value key="maxSize" type="size" width="700" height="350"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
@@ -97,7 +98,7 @@
             <point key="canvasLocation" x="-173" y="876"/>
         </customView>
         <customView id="kOW-Us-kgD" userLabel="Configure">
-            <rect key="frame" x="0.0" y="0.0" width="700" height="350"/>
+            <rect key="frame" x="0.0" y="0.0" width="700" height="410"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <box fixedFrame="YES" boxType="custom" borderType="none" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="f2W-Nn-YWU">
@@ -123,7 +124,7 @@
                     <color key="fillColor" red="0.57793885469999995" green="0.75859862570000003" blue="0.2368842065" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </box>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="660" translatesAutoresizingMaskIntoConstraints="NO" id="ikd-wz-01Q">
-                    <rect key="frame" x="15" y="310" width="664" height="54"/>
+                    <rect key="frame" x="15" y="370" width="664" height="54"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Let's configure ReiKey:" id="XHD-XH-wR0">
                         <font key="font" size="32" name="AvenirNextCondensed-Regular"/>
@@ -132,12 +133,12 @@
                     </textFieldCell>
                 </textField>
                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zct-RU-d1Y">
-                    <rect key="frame" x="20" y="120" width="189" height="147"/>
+                    <rect key="frame" x="20" y="180" width="189" height="147"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="ReiKeyIcon" id="PwK-g9-sQH"/>
                 </imageView>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="b0q-yl-6sv">
-                    <rect key="frame" x="241" y="255" width="22" height="44"/>
+                    <rect key="frame" x="242" y="320" width="22" height="44"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="6UN-fn-MkZ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -145,7 +146,7 @@
                     </buttonCell>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LHE-lc-cEL">
-                    <rect key="frame" x="241" y="187" width="22" height="44"/>
+                    <rect key="frame" x="242" y="252" width="22" height="44"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="aZp-4P-816">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -153,7 +154,7 @@
                     </buttonCell>
                 </button>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="445" translatesAutoresizingMaskIntoConstraints="NO" id="AhJ-ov-jbx">
-                    <rect key="frame" x="243" y="222" width="403" height="45"/>
+                    <rect key="frame" x="244" y="287" width="403" height="45"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Ensures continual protection." id="r1b-Nl-Ii7">
                         <font key="font" size="12" name="Menlo-Regular"/>
@@ -162,7 +163,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="445" translatesAutoresizingMaskIntoConstraints="NO" id="KHZ-VJ-JkQ">
-                    <rect key="frame" x="241" y="152" width="449" height="45"/>
+                    <rect key="frame" x="242" y="217" width="449" height="45"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Displays an icon the status bar menu." id="3aO-AI-YtY">
                         <font key="font" size="12" name="Menlo-Regular"/>
@@ -171,7 +172,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Udh-qU-3t3">
-                    <rect key="frame" x="264" y="263" width="310" height="28"/>
+                    <rect key="frame" x="265" y="328" width="310" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Start At Login" id="zo1-a0-tPg">
                         <font key="font" size="17" name="Menlo-Bold"/>
@@ -180,7 +181,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Gf8-do-3hb">
-                    <rect key="frame" x="264" y="195" width="399" height="28"/>
+                    <rect key="frame" x="265" y="260" width="399" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Run With Icon" id="ymJ-tB-qiA">
                         <font key="font" size="17" name="Menlo-Bold"/>
@@ -189,7 +190,7 @@
                     </textFieldCell>
                 </textField>
                 <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8cr-LX-DxU">
-                    <rect key="frame" x="241" y="128" width="29" height="18"/>
+                    <rect key="frame" x="242" y="193" width="29" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="SoU-7W-Bcb">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -197,7 +198,7 @@
                     </buttonCell>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="30Q-TL-2rc">
-                    <rect key="frame" x="264" y="123" width="399" height="28"/>
+                    <rect key="frame" x="265" y="188" width="399" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Ignore Apple Programs" id="it5-De-aOu">
                         <font key="font" size="17" name="Menlo-Bold"/>
@@ -206,7 +207,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="445" translatesAutoresizingMaskIntoConstraints="NO" id="NuR-yR-Chf">
-                    <rect key="frame" x="241" y="90" width="349" height="36"/>
+                    <rect key="frame" x="242" y="155" width="349" height="36"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Prevents system binaries from generating alerts and appearing in scan results." id="yZl-Jl-s2i">
                         <font key="font" size="12" name="Menlo-Regular"/>
@@ -214,8 +215,34 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Yb-YH-360">
+                    <rect key="frame" x="242" y="107" width="29" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="EUa-QG-s4F">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system" size="14"/>
+                    </buttonCell>
+                </button>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Hc-RP-dDh">
+                    <rect key="frame" x="265" y="102" width="399" height="28"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Show Current Status On Login" id="ps4-CH-rkw">
+                        <font key="font" size="17" name="Menlo-Bold"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" preferredMaxLayoutWidth="445" translatesAutoresizingMaskIntoConstraints="NO" id="n3f-x0-BTn">
+                    <rect key="frame" x="242" y="58" width="349" height="45"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Shows the current keyboard event taps on login." id="5gr-YD-fHW">
+                        <font key="font" size="12" name="Menlo-Regular"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
-            <point key="canvasLocation" x="629" y="876"/>
+            <point key="canvasLocation" x="629" y="906"/>
         </customView>
         <customView id="2qR-UH-6qk" userLabel="Support">
             <rect key="frame" x="0.0" y="0.0" width="700" height="350"/>

--- a/mainApp/mainApp/WelcomeWindowController.h
+++ b/mainApp/mainApp/WelcomeWindowController.h
@@ -29,6 +29,9 @@
 //allow 3rd-party installed apps
 @property (weak) IBOutlet NSButton *runWithIcon;
 
+//show status on login
+@property (weak) IBOutlet NSButton *showStatusOnLogin;
+
 //'ignore apple programs' button
 @property (weak) IBOutlet NSButton *ignoreAppleBinaries;
 

--- a/mainApp/mainApp/WelcomeWindowController.m
+++ b/mainApp/mainApp/WelcomeWindowController.m
@@ -69,7 +69,10 @@
         
         //set 'start at login'
         [sharedDefaults setBool:(BOOL)self.startAtLogin.state forKey:PREF_START_AT_LOGIN];
-        
+
+        //set 'show at login'
+        [sharedDefaults setBool:(BOOL)self.showStatusOnLogin.state forKey:PREF_SHOW_AT_LOGIN];
+
         //set 'run with icon'
         [sharedDefaults setBool:(BOOL)self.runWithIcon.state forKey:PREF_RUN_WITH_ICON];
         

--- a/shared/consts.h
+++ b/shared/consts.h
@@ -115,6 +115,10 @@
 #define PREF_START_AT_LOGIN @"startAtLogin"
 
 //prefs
+// start at login
+#define PREF_SHOW_AT_LOGIN @"showAtLogin"
+
+//prefs
 // run with icon
 #define PREF_RUN_WITH_ICON @"runWithIcon"
 


### PR DESCRIPTION
Hey there!

This pull adds a new setting to toggle if the scan window (`ScanWindowController`) should be shown on login. In addition to the "start at login" functionality, this one is useful for users who do not want to see the scan window on every start, which was my personal motivation on this as well.

If you have further questions, I'd be happy to answer those!