### PR TITLE
Changed bitwise logic for keyboard event taps

### DIFF
--- a/shared/EventTaps.m
+++ b/shared/EventTaps.m
@@ -34,8 +34,9 @@
     //current tap
     CGEventTapInformation tap = {0};
     
-    //key tap
-    CGEventMask keyboardTap = CGEventMaskBit(kCGEventKeyUp) | CGEventMaskBit(kCGEventKeyDown);
+    //key taps
+    CGEventMask keyUpTap = CGEventMaskBit(kCGEventKeyUp);
+    CGEventMask keyDownTap = CGEventMaskBit(kCGEventKeyDown);
     
     //tapping process
     NSString* sourcePath = nil;
@@ -81,7 +82,8 @@
         //ignore disabled taps
         // or non-keyboard taps
         if( (true != tap.enabled) ||
-            ((keyboardTap & tap.eventsOfInterest) != keyboardTap) )
+            (((keyUpTap & tap.eventsOfInterest) != keyUpTap) &&
+            ((keyDownTap & tap.eventsOfInterest) != keyDownTap)) )
         {
             //skip
             continue;


### PR DESCRIPTION
ReiKey does not find or detect keyboard event taps that are monitoring only a keydown event or only a keyup event. Based on the bitwise logic, it only finds taps that are monitoring at least both of these settings. 

I know a key press is technically made up of both a keydown event and a keyup event, but malware could gather similar data by only monitoring keyup events and ReiKey would not detect it. I think ReiKey should still present these taps to the user, even if it would be a crappy keylogger. 

The bitmask is defined here: https://github.com/objective-see/ReiKey/blob/master/shared/EventTaps.m#L38

And the bitmask is used here: https://github.com/objective-see/ReiKey/blob/master/shared/EventTaps.m#L83

I took a shot at changing the logic.